### PR TITLE
[Finishes #115585845] Reservations on dashboard

### DIFF
--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -244,7 +244,7 @@ class BookingController extends Controller
 
         $data = [];
         foreach ($cart as $item) {
-            $temp['scheduled_date'] = date('Y-m-d h:i:s', strtotime($item->attributes->date));
+            $temp['scheduled_date'] = date('Y-m-d H:i:s', strtotime($item->attributes->date));
             $temp['duration'] = $item->attributes->duration;
             $temp['type'] = $item->attributes->type;
             $temp['table_id'] = $item->attributes->item_id;

--- a/app/Http/Controllers/ReservationController.php
+++ b/app/Http/Controllers/ReservationController.php
@@ -14,7 +14,7 @@ class ReservationController extends Controller
     public function currentReservations(Request $request)
     {
         // $this->authorize('diner-user');
-        $bookings = $request->user()->bookings()->where('status', 1)->where('scheduled_date', '>', \Carbon\Carbon::now()->toDateTimeString())->get();
+        $bookings = $request->user()->bookings()->where('status', 1)->where('scheduled_date', '>=', \Carbon\Carbon::now()->toDateTimeString())->get();
 
         return view('reservations.current', ['user' => $request->user(), 'reservations' => $bookings]);
     }

--- a/database/migrations/2016_03_22_105822_change_scheduled_date_col_datatype_to_datatime_on_bookings_table.php
+++ b/database/migrations/2016_03_22_105822_change_scheduled_date_col_datatype_to_datatime_on_bookings_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeScheduledDateColDatatypeToDatatimeOnBookingsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            //
+            $table->datetime('scheduled_date')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('bookings', function (Blueprint $table) {
+            //
+            $table->date('scheduled_date')->change();
+        });
+    }
+}


### PR DESCRIPTION
#### What does this PR do?

Makes reservations booked for the current day show on the current reservations page
#### Description of Task to be completed?
- Create a new database migration file to change the column datatype of scheduled_date from date to datetime
- Change scheduled_date hour format to 24hrs format while creating a booking in the checkout method in BookingController.php
#### How should this be manually tested?

> Sign-in as a Diner > Choose table > Book the table for the current day > Pay/Checkout > Go to Reservations page > You should see the table you just booked in the list
#### What are the relevant pivotal tracker stories?

The corresponding story on _PT_ can be viewed [here](https://www.pivotaltracker.com/story/show/115585845)
#### Screenshots

![screen shot 2016-03-23 at 11 53 30 am](https://cloud.githubusercontent.com/assets/17027572/13983213/9ba20384-f0ee-11e5-80a5-2774eea07477.png)
![screen shot 2016-03-23 at 11 54 07 am](https://cloud.githubusercontent.com/assets/17027572/13983215/9ba304d2-f0ee-11e5-9440-bd0b08368ec0.png)
![screen shot 2016-03-23 at 11 54 50 am](https://cloud.githubusercontent.com/assets/17027572/13983216/9ba3e00a-f0ee-11e5-9963-7031c6b577ff.png)
![screen shot 2016-03-23 at 11 57 52 am](https://cloud.githubusercontent.com/assets/17027572/13983214/9ba2b932-f0ee-11e5-9e0e-8b3eaa8efbbe.png)
