### PR TITLE
[Chores #116617269] Redesign the navigation search box

### DIFF
--- a/public/css/navbar-search.css
+++ b/public/css/navbar-search.css
@@ -1,0 +1,26 @@
+.search-row {
+    margin: 0;
+    margin-left: 0px;
+    width: auto;
+    border-bottom: solid #fff 1px;
+    background: none;
+}
+
+.search-right {
+    padding: 0px;
+    text-align: left;
+}
+
+.search-left {
+    padding: 0px;
+    bottom: -6px;
+    text-align: center;
+}
+
+.search-text {
+    background: none;
+    border: none;
+}
+
+.search-icon {
+}

--- a/public/js/search.js
+++ b/public/js/search.js
@@ -1,5 +1,15 @@
 $(document).ready(function() {
-    $(".flip").click(function() {
-        $( ".search-text" ).toggle("slide");
+    $(".search-icon").click(function() {
+        $(".search-text").focus();
+    });
+    $(".search-text").on("focus", function () {
+        $(this).css( "background", "#eee" );
+        $(".search-row").css( "border-bottom", "3px solid #fff" );
+        $(this).attr('placeholder', "Search for restaurant... name or location.");
+    });
+    $(".search-text").on("blur", function () {
+        $(this).css( "background", "none" );
+        $(".search-row").css( "border-bottom", "1px solid #fff" );
+        $(".search-text").attr('placeholder', "")
     });
 });

--- a/resources/views/partials/search.blade.php
+++ b/resources/views/partials/search.blade.php
@@ -1,15 +1,13 @@
-
-<form action="{{ route('searchsite') }}" class="navbar-form navbar-search" role="search">
-    <div class="row">
-        <div class="col-md-1">
-                <span class="glyphicon glyphicon-search flip" style="color:#fff; width: 100%;"></span>
-        </div>
-        <div class="col-md-11">
-            <div class="row search-panel">
-                <div class="col-md-12" id="search-text">
-                    <input type="text" width="100%" style="width:100%; height:100%; display:none;" class="form-control search-text" required id="query" name="query" placeholder="Search for restaurant... name or location">
-                </div>
+<link rel="stylesheet" type="text/css" href="{{asset('css/navbar-search.css')}}">
+<div class="search-form">
+    <form action="{{ route('searchsite') }}" class="navbar-form" role="search">
+        <div class="row search-row">
+            <div class="col-md-1 search-left">
+                <span class="glyphicon glyphicon-search search-icon" style="color:#fff; width: 100%;"></span>
+            </div>
+            <div class="col-md-11 search-right">
+                <input type="text" width="100%" style="width:100%; height:100%;" class="form-control search-text" required id="query" name="query" placeholder="">
             </div>
         </div>
-    </div>
-</form>
+    </form>
+</div>


### PR DESCRIPTION
#### What does this PR do?

Redesigns the search input box on the navigation bar.
#### Description of Task to be completed?

Make the background colour of the search box to be white on focus, otherwise have the same colour with the parent navigation bar.
#### How should this be manually tested?

On any page, apart from the welcome page, click on the search icon to search for a restaurant.
#### Any background context you want to provide?

The search bar blends with the navigation bar except when it comes alive when clicked on on focus.
#### What are the relevant pivotal tracker stories?

The corresponding story on Tracker can be viewed [here](https://www.pivotaltracker.com/projects/1415814/stories/116617269).
#### Screenshots (if appropriate)

![screen shot 2016-03-30 at 4 12 30 pm](https://cloud.githubusercontent.com/assets/17028608/14148139/3fde78b8-f696-11e5-86f3-0f5f68b88a59.png)

![screen shot 2016-03-30 at 4 12 45 pm](https://cloud.githubusercontent.com/assets/17028608/14148138/3fba3994-f696-11e5-845c-d28c932585f6.png)

![screen shot 2016-03-30 at 4 13 40 pm](https://cloud.githubusercontent.com/assets/17028608/14148137/3f90508e-f696-11e5-82cc-715f35e2582f.png)
#### Questions:

There are no questions at the moment.
