### PR TITLE
#116513035 Effect Changes About & Contact Us page

### DIFF
--- a/public/css/inner.css
+++ b/public/css/inner.css
@@ -52,17 +52,18 @@ body{
     /* min-height: 100%; */
     padding: 0;
 }
-.navbar{
-    background:rgba(235, 43, 54, 1);
-    top:0;
-    padding: 10px;
+.navbar {
+    background: rgba(253, 43, 54, 1);
+    top: 0;
+    padding: 6px;
 }
 
-
-
-.navbar a:hover{
-    color: #BBB24D !important;
+.navbar-right li a:hover {
+    background-color: #fed;
+    color: #990000;
+    border-radius: 3px;
 }
+
 .page-content{
     background: #FFF;
     min-height: 100%;

--- a/public/css/inner.css
+++ b/public/css/inner.css
@@ -58,8 +58,13 @@ body{
     padding: 6px;
 }
 
+.navbar a:hover {
+    display: block;
+    color: #fff;
+    border-radius: 3px;
+}
+
 .navbar-right li a:hover {
-    background-color: #fed;
     color: #990000;
     border-radius: 3px;
 }
@@ -72,7 +77,6 @@ body{
     border-top:6px solid #00b075;
     background: #FFF;
 }
-
 
 .nav-pills li a{
     color:#333;
@@ -296,4 +300,8 @@ body{
 
 #contactus i.fa {
     width: 20px;
+}
+
+.dropdown-menu {
+    background: rgba(0,0,0,0.69);
 }

--- a/resources/views/aboutus.blade.php
+++ b/resources/views/aboutus.blade.php
@@ -5,7 +5,6 @@
     @parent
     <link href='https://fonts.googleapis.com/css?family=Pacifico|Lato:400,100' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700">
-    <link rel='stylesheet' type="text/css" href="{!! asset('css/registration.css') !!}"/>
     <link rel='stylesheet' type="text/css" href="{!! asset('css/bootstrap-social.css') !!}"/>
 @endsection
 @section('details')

--- a/resources/views/contactus.blade.php
+++ b/resources/views/contactus.blade.php
@@ -5,7 +5,6 @@
     @parent
     <link href='https://fonts.googleapis.com/css?family=Pacifico|Lato:400,100' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700">
-    <link rel='stylesheet' type="text/css" href="{!! asset('css/registration.css') !!}"/>
     <link rel='stylesheet' type="text/css" href="{!! asset('css/bootstrap-social.css') !!}"/>
 @endsection
 @section('details')
@@ -38,7 +37,4 @@
     </div>
 
 @endsection
-
-
-Contact Us
 


### PR DESCRIPTION
#### What does this PR do?

Fix the hover colour for the navigation links for the About Us and Contact Pages.
#### Description of Task to be completed?
- Update `inner.css`
- Remove redundant link in `aboutus.blade.php` and `contactus.blade.php` file 
- Remove redundant text `Contact Us` in `contactus.blade.php` file 
#### How should this be manually tested?

Landing page > click on Contact us link on Navbar > Hover navigation links on the Navbar
Landing page > click on About us link on Navbar > Hover navigation links on the Navbar
#### What are the relevant pivotal tracker stories?

The corresponding story on `PT` can be viewed [here](https://www.pivotaltracker.com/story/show/116513035)
#### Screenshots (if appropriate)

![screen shot 2016-04-05 at 6 13 55 pm](https://cloud.githubusercontent.com/assets/17027572/14291208/5f9c312c-fb5a-11e5-87d7-2566a074255a.png)
![screen shot 2016-04-05 at 6 14 34 pm](https://cloud.githubusercontent.com/assets/17027572/14291207/5f9bb29c-fb5a-11e5-8ea4-39158cf37bab.png)
