### PR TITLE
 #117325453 Prevent table double booking

### DIFF
--- a/app/Booking.php
+++ b/app/Booking.php
@@ -37,4 +37,14 @@ class Booking extends Model
 
         return $restaurant;
     }
+
+    public function scopeConflictBooking($query, $tableId, $bookingDate, $bookingDuration)
+    {
+        return $query->where('table_id', '=', $tableId)
+                    ->where(function ($query) use ($bookingDate) {
+                            $query->where('scheduled_date', '<=', $bookingDate)
+                                  ->whereRaw('(scheduled_date + INTERVAL `duration` HOUR) > ?', [$bookingDate]);
+                    })
+                    ->whereRaw('(? - (`scheduled_date` + INTERVAL `duration` HOUR)) < ?', [$bookingDate, $bookingDuration]);
+    }
 }

--- a/app/Http/Controllers/BookingController.php
+++ b/app/Http/Controllers/BookingController.php
@@ -208,6 +208,13 @@ class BookingController extends Controller
             ]
         );
 
+        $date = str_replace('/', '-', $request->date);
+        $bookingDate = date('Y-m-d H:i:s', strtotime($date));
+
+        $conflictBooking = Booking::conflictBooking($request->table_id, $bookingDate, $request->duration)->take(1)->get();
+        if (!$conflictBooking->isEmpty()) {
+            return redirect()->back()->with('error', 'Sorry, This table is not available at the selected time slot.');
+        }
         if ($validator->fails()) {
             return redirect()
                 ->back()
@@ -268,15 +275,24 @@ class BookingController extends Controller
     public function checkout(Request $request)
     {
         $user = Auth::user();
+        $cart = Cart::getContent();
+        $data = [];
+
+        foreach ($cart as $item) {
+            $date = str_replace('/', '-', $item->attributes->date);
+            $bookingDate = date('Y-m-d H:i:s', strtotime($date));
+            $conflictBooking = Booking::conflictBooking($item->attributes->item_id, $bookingDate, $item->attributes->duration)->take(1)->get();
+            if (!$conflictBooking->isEmpty()) {
+                $table = Table::find($item->attributes->item_id);
+                return redirect('/booking/cart')->with('error', 'Sorry, The selected table , '.$table->label.', is no longer available at the selected time slot.');
+            }
+        }
 
         $return = $user->charge(Cart::getTotal() * 100, [
             'source' => $request->stripeToken,
             'receipt_email' => $user->email,
         ]);
 
-        $cart = Cart::getContent();
-
-        $data = [];
         foreach ($cart as $item) {
             $temp['scheduled_date'] = date('Y-m-d H:i:s', strtotime($item->attributes->date));
             $temp['duration'] = $item->attributes->duration;
@@ -287,8 +303,6 @@ class BookingController extends Controller
             Booking::create($temp);
             $data[] = $temp;
         }
-
-        // Booking::create($data);
 
         //clear cart
         $this->clearCart();


### PR DESCRIPTION
#### What does this PR do?

 Prevent table double booking
#### Description of Task to be completed?
- Add method `scopeConflictBooking` in `booking.php` to fetch bookings that conflict with the selected booking time slot
- Ensure no conflicting booking is found before adding a table booking into the cart and during checkout in `BookingController.php`
#### How should this be manually tested?
- Landing page > Login > Book a table for a time slot > Pay (Checkout) > Try Booking the same table for the same time slot > You should get an error message saying you can't book the table

> Note: You'd two accounts to test this
- Landing page > Login with Account 1 > Open a new browser window (incognito) > Login with Account 2 >  Book (Add to Cart) a table for a time slot with Account 1 > Book the same table for the same time slot with Account 2 > Pay for the Booking with Account 1 > Try to Pay for the Booking with Account 2 > You should get an error message saying you can't book the table
#### What are the relevant pivotal tracker stories?

The corresponding story on `PT` can be viewed [here](https://www.pivotaltracker.com/story/show/117325453)

![screen shot 2016-04-19 at 11 50 48 am](https://cloud.githubusercontent.com/assets/17027572/14637305/62dba362-0628-11e6-98dd-76c77c42346e.png)
![screen shot 2016-04-19 at 12 09 23 pm](https://cloud.githubusercontent.com/assets/17027572/14637304/62db9f84-0628-11e6-82aa-0949684fcb65.png)
