### PR TITLE
[Hotfix #118371105] Fix the bug with the username route

### DIFF
--- a/app/Http/Controllers/UserProfileController.php
+++ b/app/Http/Controllers/UserProfileController.php
@@ -8,7 +8,7 @@ use Resly\User;
 
 class UserProfileController extends Controller
 {
-    public function getProfile($username)
+    public function getProfile()
     {
         return view('profile.user');
     }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -145,7 +145,7 @@ Route::post('/user/profile/edit', [
     'middleware' => 'auth',
 ]);
 
-Route::get('/user/{username}', [
+Route::get('/user', [
     'uses' => 'UserProfileController@getProfile',
     'as' => 'userProfile',
     'middleware' => 'auth',

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -49,7 +49,7 @@
                                             {{ auth()->user()->username }} <span class = "caret"></span>
                                         </a>
                                         <ul class="dropdown-menu " role = "menu">
-                                            <li><a href="{{ route('userProfile', ['username' => auth()->user()->username]) }}">Your Profile</a></li>
+                                            <li><a href="{{ route('userProfile') }}">Your Profile</a></li>
                                             <li>
                                                 @can('restaurateur-user')
                                                     <a href="{{url('/restaurants')}}">My Restaurants</a>

--- a/resources/views/partials/navbar.blade.php
+++ b/resources/views/partials/navbar.blade.php
@@ -37,7 +37,7 @@
                                 @endcan
 
                                 <li><a href="#">Restaurants</a></li>
-                               
+
                                 @can('authenticated')
                                     <li>
                                         <a href="{{url('/booking/cart')}}">


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the bug with the username parameter.
#### Description of Task to be completed?

The username parameter in the userProfile route is removed because it is not being used.
#### How should this be manually tested?

> Landing page (after login)
> Hover User link (top-right of the screen)
> Click `Your Profile` to visit the user's profile.
#### Any background context you want to provide?

Whenever a user tries to view his/her profile, the username was previously passed to the method as a parameter.
This username is never used and sometimes causes problems. It is therefore to be removed.
#### What are the relevant pivotal tracker stories?

This story can be viewed on PT [here](https://www.pivotaltracker.com/projects/1415814/stories/118371105).
#### Questions:

The username property can still be used, to fetch the user with the username and return to the view.
Can any user view the profile of another person?
